### PR TITLE
Allow updates without date change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Instrucoes para contribuidores do plugin COD5
+
+Este repositório contém o plugin **COD5 Validação de Data Retroativa** para WordPress.
+Siga estas diretrizes ao editar arquivos:
+
+## Estilo de Código
+- PHP no padrão WordPress, indentado com 4 espaços.
+- Comentários sempre em português.
+- Evite usar funções não compatíveis com PHP 7.2.
+
+## Testes Rápidos
+Antes de commitar, execute:
+```bash
+php -l cod5-validacao-data-retroativa.php
+node --check admin.js
+```
+A validação PHP pode não estar disponível no ambiente. Se falhar por comando não encontrado,
+registre essa informação no resumo de testes.
+
+## Ajustes no Plugin
+- Todas as configurações estão na classe `COD5_Config`.
+- Utilize `COD5_Utils::debug_log` para mensagens de depuração.
+- A função `cod5_validar_data_retroativa` é o ponto central de validação. Já inclui uma
+verificação para pular validação em atualizações onde a data não mudou.
+
+## Documentação
+Atualize `README.md` sempre que adicionar novas funcionalidades ou comportamentos.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ const STATUS_VALIDADOS = array(
 const MENSAGEM_PADRAO = 'Sua mensagem personalizada aqui.';
 ```
 
+#### 6. Edição sem Alterar Data
+Autores podem atualizar posts já publicados sem acionar a validação de data retroativa,
+desde que a data de publicação permaneça exatamente a mesma. Qualquer mudança na data
+continuará passando pelas regras normais de validação.
+
 ## 🚀 Instalação
 
 1. Faça upload do plugin para `/wp-content/plugins/`

--- a/cod5-validacao-data-retroativa.php
+++ b/cod5-validacao-data-retroativa.php
@@ -231,6 +231,26 @@ function cod5_validar_data_retroativa( $user_id, $user_login, $post_id, $post_ty
 
     COD5_Utils::debug_log("Validando: User ID {$user_id}, Post ID {$post_id}, Status {$post_status}, Data {$post_date}");
 
+    // Se for uma atualização e a data não mudou, pula a validação
+    if ( $acao === 'atualizacao' && $post_id > 0 ) {
+        $original_post = get_post( $post_id );
+        $original_date = $original_post ? $original_post->post_date : '';
+
+        if ( $original_date ) {
+            $original_dt = new DateTime( $original_date );
+            $post_dt     = new DateTime( $post_date );
+
+            // Ignora os segundos na comparação
+            $original_dt->setTime( $original_dt->format('H'), $original_dt->format('i'), 0 );
+            $post_dt->setTime( $post_dt->format('H'), $post_dt->format('i'), 0 );
+
+            if ( $original_dt->format('Y-m-d H:i') === $post_dt->format('Y-m-d H:i') ) {
+                COD5_Utils::debug_log('Data original e nova iguais. Pulando validação.');
+                return true;
+            }
+        }
+    }
+
     // Verifica se o status deve ser validado
     if ( ! COD5_Utils::status_deve_ser_validado( $post_status ) ) {
         COD5_Utils::debug_log("Status {$post_status} não requer validação");


### PR DESCRIPTION
## Summary
- skip retroactive date validation when updating without changing the post date
- clarify in the README that authors can edit posts if the publication date stays the same
- add contributor guide in `AGENTS.md`

## Testing
- `php -l cod5-validacao-data-retroativa.php` *(fails: command not found)*
- `node --check admin.js`

------
https://chatgpt.com/codex/tasks/task_e_6852c56244088328a375b71814991bbe